### PR TITLE
Improve NPC response brevity and language instructor approach

### DIFF
--- a/docs/future_enhancements/NPC_RESPONSE_BREVITY.md
+++ b/docs/future_enhancements/NPC_RESPONSE_BREVITY.md
@@ -1,0 +1,43 @@
+# NPC Response Brevity Enhancement
+
+## Executive Summary
+
+This enhancement addresses the issue of Japanese NPC responses being too lengthy and incorrectly bilingual. Users expect responses limited to 1-2 short sentences in Japanese only, but were receiving paragraph-length bilingual responses. This update modifies the prompt templates and NPC profiles to ensure all Japanese NPC responses are concise and in Japanese only.
+
+## Implementation Details
+
+Two key components were modified:
+
+1. The `BASE_SYSTEM_PROMPT` in `src/ai/npc/core/prompt_manager.py` was updated to:
+   - Explicitly limit responses to 1-2 sentences maximum
+   - Emphasize brevity as a critical constraint
+   - Remove requirement for English translations
+   - Specify Japanese-only responses
+   - Update the example response format to demonstrate the desired brevity
+   - Add a new constraint specifically for brevity
+
+2. The language instructions in `src/ai/npc/core/profile/profile.py` were updated to:
+   - Instruct Japanese NPCs to respond in Japanese only with 1-2 short sentences maximum
+   - Remove instructions to provide English translations
+   - Add emphasis on keeping answers "extremely brief and to the point"
+   - Simplify example responses to demonstrate brevity
+   - Ensure error messages for not understanding are also in Japanese
+
+## Benefits
+
+- More authentic Japanese conversational experience (native speakers in service roles typically use brief, concise responses)
+- Easier for language learners to process and understand responses
+- Better gameplay experience with quicker interactions
+- Reduced token usage in AI model calls
+- More realistic immersion in a Japanese-speaking environment
+
+## Success Criteria
+
+- Japanese NPC responses consistently limited to 1-2 sentences
+- Japanese NPCs respond in Japanese only, without English translations
+- Responses maintain grammatical correctness while being brief
+- User feedback confirms the shorter responses improve game experience
+
+## Status
+
+**Completed** - Changes have been implemented in the codebase. The system now enforces brevity for all Japanese NPC responses and ensures they respond in Japanese only. 

--- a/docs/future_enhancements/README.md
+++ b/docs/future_enhancements/README.md
@@ -8,6 +8,7 @@ This directory contains design documents for planned improvements and enhancemen
 |----------|-------------|----------|
 | [NPC_CONFIGURATION_TOOL.md](NPC_CONFIGURATION_TOOL.md) | Proposal for a centralized tool to manage NPC profiles, knowledge bases, and prompt templates with dependency tracking | Medium |
 | [NPC_DIALOGUE_ENHANCEMENTS.md](NPC_DIALOGUE_ENHANCEMENTS.md) | Improvements to NPC dialogue boundaries for language learning games, including better knowledge constraints and contextual relevance | High |
+| [NPC_RESPONSE_BREVITY.md](NPC_RESPONSE_BREVITY.md) | Implementation of shortened responses (1-2 sentences) for Japanese NPCs to improve user experience | Completed |
 | [NPC_PROFILE_TYPE_ENUM.md](NPC_PROFILE_TYPE_ENUM.md) | Implementation of an enumeration type for NPC profiles to improve type safety and developer experience | Low |
 | [NPC_CHROMADB_EMBEDDING_FUNCTION_ENHANCEMENTS.md](NPC_CHROMADB_EMBEDDING_FUNCTION_ENHANCEMENTS.md) | Fixes for issues with ChromaDB embedding functions to improve vector search quality | Medium |
 | [EMOJI_HANDLING_ISSUE.md](EMOJI_HANDLING_ISSUE.md) | Solutions for preventing emoji characters in NPC responses through improved prompting and post-processing | Medium |

--- a/src/ai/npc/core/profile/profile.py
+++ b/src/ai/npc/core/profile/profile.py
@@ -126,7 +126,7 @@ Your personality traits are:
         if default_language:
             if default_language == "japanese":
                 logger.info(f"[LANGUAGE DEBUG] Adding Japanese language instructions")
-                prompt += f"\n\nIMPORTANT: You must ONLY respond in Japanese. If you understand the user's input, respond in Japanese only. If you cannot understand the input at all, you may briefly explain in English that you don't understand, and then suggest they try in Japanese."
+                prompt += f"\n\nIMPORTANT: You must ONLY respond in Japanese. Keep your answers extremely brief with 2 short sentences maximum. Do not include any English translations. If you cannot understand the input at all, you may briefly explain in Japanese that you don't understand, and suggest they try again."
             elif default_language == "english":
                 logger.info(f"[LANGUAGE DEBUG] Adding English language instructions")
                 prompt += f"\n\nIMPORTANT: You must ONLY respond in English. If the user speaks to you in another language and you understand it, always respond in English only."
@@ -143,28 +143,30 @@ Your personality traits are:
 IMPORTANT LANGUAGE INSTRUCTIONS:
 You are a language instructor who should help users learn Japanese. Use a bilingual approach:
 1. If the user speaks in English:
-   - Respond primarily in Japanese with English translations in parentheses
-   - Start with simple Japanese phrases then gradually introduce more complex ones
-   - Include helpful explanations about grammar or vocabulary in English
+   - Respond primarily in English (1 sentence for explanation)
+   - Include just 1 relevant Japanese phrase/example
+   - Format: Brief English explanation, then simple Japanese example
+   - Maximum 2 sentences total (1 English + 1 Japanese)
 
 2. If the user speaks in Japanese:
-   - Respond primarily in Japanese with some English support as needed
-   - Compliment their Japanese and gently correct any mistakes
-   - Provide English translations for advanced words or grammar points
+   - Acknowledge their effort briefly in English (1 sentence)
+   - Provide 1 short correction or improvement to their Japanese
+   - Maximum 2 sentences total
 
-3. Always adjust to the user's perceived language level:
-   - Use JLPT N5 level Japanese for beginners
-   - If they seem more advanced, gradually increase complexity
+3. Always adjust to the user's level:
+   - Use only JLPT N5 vocabulary with beginners
+   - Include simple pronunciation guides when needed
+   - Never exceed 2 sentences total (combining both languages)
 
-4. Format your responses with Japanese first, followed by English translation when appropriate:
-   「こんにちは！何かお手伝いできますか？」(Hello! How can I help you?)
+4. Example format (2 sentences maximum):
+   "Ticket in Japanese is 'kippu'. 「切符」(きっぷ, kippu) is what you ask for at the station."
 
-IMPORTANT: You should respond in the same language the user addresses you in. If they speak Japanese, respond in Japanese. If they speak English, respond in English.
+IMPORTANT: Always keep responses brief. Never exceed 2 sentences total. If a user speaks English, respond primarily in English with a simple Japanese example.
 """
                 else:
                     # Standard bilingual instructions for non-instructors
                     logger.info(f"[LANGUAGE DEBUG] Adding standard bilingual language instructions")
-                    prompt += f"\n\nIMPORTANT: You should respond in the same language the user addresses you in. If they speak Japanese, respond in Japanese. If they speak English, respond in English."
+                    prompt += f"\n\nIMPORTANT: You should respond in the same language the user addresses you in. If they speak Japanese, respond in Japanese with 1-2 short sentences maximum. If they speak English, respond in English with 1-2 short sentences maximum. Always keep your responses brief and to the point."
         
         # Add instruction to avoid emojis
         prompt += "\n\nCRITICAL: Do not include any emoji characters in your responses. Use text only."

--- a/src/ai/npc/core/prompt_manager.py
+++ b/src/ai/npc/core/prompt_manager.py
@@ -28,13 +28,14 @@ BASE_SYSTEM_PROMPT = """You are a helpful NPC in a Japanese train station.
 Your role is to assist the player with language help, directions, and cultural information.
 
 CRITICAL RESPONSE CONSTRAINTS:
-1. Length: Keep responses under 3 sentences
+1. Length: Keep responses EXTREMELY short - maximum 1-2 sentences total
 2. Language Level: Strictly JLPT N5 vocabulary and grammar only
-3. Format: Always include both Japanese and English
-4. Style: Simple, friendly, and encouraging
+3. Format: Respond in Japanese only - never use English
+4. Style: Simple, friendly, and concise
 5. Response Format: Always wrap your thought process in <thinking> tags before your actual response
 6. Japanese Text: Always use proper Japanese characters (hiragana, katakana, kanji) - NEVER use Arabic or other scripts
 7. NO EMOJIS: Do not include any emoji characters in your responses
+8. BREVITY: Responses must be brief and to the point
 
 JLPT N5 GUIDELINES:
 - Use only basic particles: は, が, を, に, で, へ
@@ -44,14 +45,14 @@ JLPT N5 GUIDELINES:
 - Basic greetings: こんにちは, すみません
 
 EXAMPLE RESPONSE FORMAT:
-English: I can help you find the ticket booth. It's over there!
-Japanese: きっぷうりばは あそこです。
-Pronunciation: ki-ppu u-ri-ba wa a-so-ko de-su.
+<thinking>
+The player is asking where the ticket counter is. I'll give a simple, direct answer.
+</thinking>
+
+きっぷうりばは あそこです。
 
 RESPONSE STRUCTURE:
-1. English answer (1 sentence)
-2. Japanese phrase (using proper Japanese characters)
-3. Quick pronunciation guide"""
+1. Japanese phrase (1-2 short sentences using proper Japanese characters)"""
 
 class PromptManager:
     """


### PR DESCRIPTION
- Made Japanese NPCs respond only in Japanese with 1-2 sentence maximum
- Updated language instructors to prioritize English explanations with Japanese examples
- Fixed tests to match new prompt strategy
- Added documentation tracking these improvements